### PR TITLE
Mesh Nav Update

### DIFF
--- a/mesh_navigation_tutorials/config/mbf_mesh_nav.yaml
+++ b/mesh_navigation_tutorials/config/mbf_mesh_nav.yaml
@@ -30,7 +30,13 @@ move_base_flex:
     cmd_vel_ignored_tolerance: 10.0
 
     mesh_map:
-      mesh_part: 'mesh'
+      mesh_file: '/home/amock/mesh_nav_ws/src/mesh_navigation_tutorials/mesh_navigation_tutorials/maps/parking_garage.ply'
+      mesh_part: '/'
+      
+      mesh_working_file: 'parking_garage.h5'
+      mesh_working_part: 'mesh'
+
+      hem: pmp # pmp (default), lvr
 
       layers: ['border', 'height_diff', 'roughness', 'inflation']
 
@@ -53,8 +59,8 @@ move_base_flex:
       inflation:
         type: 'mesh_layers/InflationLayer'
         factor: 1.0
-        inflation_radius: 0.4
-        inscribed_radius: 0.2
+        inflation_radius: 0.2
+        inscribed_radius: 0.4
         lethal_value: 1.0
         inscribed_value: 0.8
         repulsive_field: false

--- a/mesh_navigation_tutorials/config/mbf_mesh_nav.yaml
+++ b/mesh_navigation_tutorials/config/mbf_mesh_nav.yaml
@@ -30,12 +30,14 @@ move_base_flex:
     cmd_vel_ignored_tolerance: 10.0
 
     mesh_map:
-      mesh_file: '/home/amock/mesh_nav_ws/src/mesh_navigation_tutorials/mesh_navigation_tutorials/maps/parking_garage.ply'
+      # input
+      # mesh_file: '/home/amock/mesh_nav_ws/src/mesh_navigation_tutorials/mesh_navigation_tutorials/maps/parking_garage.ply'
       mesh_part: '/'
-      
-      mesh_working_file: 'parking_garage.h5'
+      # storage
+      # mesh_working_file: 'parking_garage.h5'
       mesh_working_part: 'mesh'
 
+      # half-edge-mesh implementation
       hem: pmp # pmp (default), lvr
 
       layers: ['border', 'height_diff', 'roughness', 'inflation']

--- a/mesh_navigation_tutorials/launch/mbf_mesh_navigation_server_launch.py
+++ b/mesh_navigation_tutorials/launch/mbf_mesh_navigation_server_launch.py
@@ -44,8 +44,13 @@ def generate_launch_description():
             "mesh_map_path",
             description="Path to the mesh file that defines the map.",
         ),
+        DeclareLaunchArgument(
+            "mesh_map_working_path",
+            description="Path to the mesh file that defines the map.",
+        ),
     ]
     mesh_map_path = LaunchConfiguration("mesh_map_path")
+    mesh_map_working_path = LaunchConfiguration("mesh_map_working_path")
 
     mbf_mesh_nav_config = os.path.join(
         get_package_share_directory("mesh_navigation_tutorials"), "config", "mbf_mesh_nav.yaml"
@@ -60,10 +65,13 @@ def generate_launch_description():
         ],
         parameters=[
             mbf_mesh_nav_config,
-            # {"mesh_map.mesh_file": mesh_map_path},
+            {
+                "mesh_map.mesh_file": mesh_map_path,
+                "mesh_map.mesh_working_file": mesh_map_working_path
+            }
         ],
-        arguments=['--ros-args', '--log-level', ['move_base_flex:=', 'DEBUG']],
-        prefix=['xterm -e gdb --args']
+        # arguments=['--ros-args', '--log-level', ['move_base_flex:=', 'DEBUG']],
+        # prefix=['xterm -e gdb --args']
     )
 
     return LaunchDescription(

--- a/mesh_navigation_tutorials/launch/mbf_mesh_navigation_server_launch.py
+++ b/mesh_navigation_tutorials/launch/mbf_mesh_navigation_server_launch.py
@@ -42,11 +42,11 @@ def generate_launch_description():
     launch_args = [
         DeclareLaunchArgument(
             "mesh_map_path",
-            description="Path to the mesh file that defines the map.",
+            description="Path to the mesh file that defines the map. Allowed formats are our internal HDF5 format and all standard mesh formats loadable by Assimp.",
         ),
         DeclareLaunchArgument(
             "mesh_map_working_path",
-            description="Path to the mesh file that defines the map.",
+            description="Path to the mesh file used by the mesh navigation to store costs during operation. Only HDF5 formats are permitted.",
         ),
     ]
     mesh_map_path = LaunchConfiguration("mesh_map_path")
@@ -69,9 +69,7 @@ def generate_launch_description():
                 "mesh_map.mesh_file": mesh_map_path,
                 "mesh_map.mesh_working_file": mesh_map_working_path
             }
-        ],
-        # arguments=['--ros-args', '--log-level', ['move_base_flex:=', 'DEBUG']],
-        # prefix=['xterm -e gdb --args']
+        ]
     )
 
     return LaunchDescription(

--- a/mesh_navigation_tutorials/launch/mbf_mesh_navigation_server_launch.py
+++ b/mesh_navigation_tutorials/launch/mbf_mesh_navigation_server_launch.py
@@ -42,7 +42,7 @@ def generate_launch_description():
     launch_args = [
         DeclareLaunchArgument(
             "mesh_map_path",
-            description="Path to the mesh file that defines the map." 
+            description="Path to the mesh file that defines the map."
             "Allowed formats are our internal HDF5 format and all"
             "standard mesh formats loadable by Assimp.",
         ),

--- a/mesh_navigation_tutorials/launch/mbf_mesh_navigation_server_launch.py
+++ b/mesh_navigation_tutorials/launch/mbf_mesh_navigation_server_launch.py
@@ -42,11 +42,14 @@ def generate_launch_description():
     launch_args = [
         DeclareLaunchArgument(
             "mesh_map_path",
-            description="Path to the mesh file that defines the map. Allowed formats are our internal HDF5 format and all standard mesh formats loadable by Assimp.",
+            description="Path to the mesh file that defines the map." 
+            "Allowed formats are our internal HDF5 format and all"
+            "standard mesh formats loadable by Assimp.",
         ),
         DeclareLaunchArgument(
             "mesh_map_working_path",
-            description="Path to the mesh file used by the mesh navigation to store costs during operation. Only HDF5 formats are permitted.",
+            description="Path to the mesh file used by the mesh navigation "
+            "to store costs during operation. Only HDF5 formats are permitted.",
         ),
     ]
     mesh_map_path = LaunchConfiguration("mesh_map_path")

--- a/mesh_navigation_tutorials/launch/mbf_mesh_navigation_server_launch.py
+++ b/mesh_navigation_tutorials/launch/mbf_mesh_navigation_server_launch.py
@@ -60,8 +60,10 @@ def generate_launch_description():
         ],
         parameters=[
             mbf_mesh_nav_config,
-            {"mesh_map.mesh_file": mesh_map_path},
+            # {"mesh_map.mesh_file": mesh_map_path},
         ],
+        arguments=['--ros-args', '--log-level', ['move_base_flex:=', 'DEBUG']],
+        prefix=['xterm -e gdb --args']
     )
 
     return LaunchDescription(

--- a/mesh_navigation_tutorials/launch/mesh_navigation_tutorial_launch.py
+++ b/mesh_navigation_tutorials/launch/mesh_navigation_tutorial_launch.py
@@ -50,13 +50,16 @@ def generate_launch_description():
     # Comment Alex: One can have different maps for same worlds
     # Is this to much choice for a tutorial?
 
-    # Launch arguments
+    # Loading a map files with the following extension
+    mesh_nav_map_ext = ".ply"
+
     available_map_names = [
-        f[:-4]
+        f[:-len(mesh_nav_map_ext)]
         for f in os.listdir(os.path.join(pkg_mesh_navigation_tutorials, "maps"))
-        if f.endswith(".dae")
+        if f.endswith(mesh_nav_map_ext)
     ]
 
+    # Launch arguments
     launch_args = [
         DeclareLaunchArgument(
             "map_name",
@@ -165,10 +168,10 @@ def generate_launch_description():
                 [
                     pkg_mesh_navigation_tutorials,
                     "maps",
-                    PythonExpression(['"', map_name, '" + ".ply"']),
+                    PythonExpression(['"', map_name, mesh_nav_map_ext, '"']), # loading a map from here
                 ]
             ),
-            "mesh_map_working_path": PythonExpression(['"', map_name, '" + ".h5"'])
+            "mesh_map_working_path": PythonExpression(['"', map_name, '" + ".h5"']) # working on a local copy (as HDF5 format)
         }.items(),
     )
 

--- a/mesh_navigation_tutorials/launch/mesh_navigation_tutorial_launch.py
+++ b/mesh_navigation_tutorials/launch/mesh_navigation_tutorial_launch.py
@@ -165,9 +165,10 @@ def generate_launch_description():
                 [
                     pkg_mesh_navigation_tutorials,
                     "maps",
-                    PythonExpression(['"', map_name, '" + ".h5"']),
+                    PythonExpression(['"', map_name, '" + ".ply"']),
                 ]
             ),
+            "mesh_map_working_path": PythonExpression(['"', map_name, '" + ".h5"'])
         }.items(),
     )
 

--- a/mesh_navigation_tutorials/launch/mesh_navigation_tutorial_launch.py
+++ b/mesh_navigation_tutorials/launch/mesh_navigation_tutorial_launch.py
@@ -168,10 +168,10 @@ def generate_launch_description():
                 [
                     pkg_mesh_navigation_tutorials,
                     "maps",
-                    PythonExpression(['"', map_name, mesh_nav_map_ext, '"']), # loading a map from here
+                    PythonExpression(['"', map_name, mesh_nav_map_ext, '"']),
                 ]
             ),
-            "mesh_map_working_path": PythonExpression(['"', map_name, '" + ".h5"']) # working on a local copy (as HDF5 format)
+            "mesh_map_working_path": PythonExpression(['"', map_name, '" + ".h5"'])
         }.items(),
     )
 

--- a/mesh_navigation_tutorials/launch/mesh_navigation_tutorial_launch.py
+++ b/mesh_navigation_tutorials/launch/mesh_navigation_tutorial_launch.py
@@ -52,9 +52,9 @@ def generate_launch_description():
 
     # Launch arguments
     available_map_names = [
-        f[:-3]
+        f[:-4]
         for f in os.listdir(os.path.join(pkg_mesh_navigation_tutorials, "maps"))
-        if f.endswith(".h5")
+        if f.endswith(".dae")
     ]
 
     launch_args = [

--- a/source_dependencies.yaml
+++ b/source_dependencies.yaml
@@ -4,7 +4,7 @@ repositories:
   lvr2:
     type: git
     url: https://github.com/uos/lvr2.git
-    version: humble
+    version: version-upgrade
   mesh_tools:
     type: git
     url: https://github.com/naturerobots/mesh_tools.git

--- a/source_dependencies.yaml
+++ b/source_dependencies.yaml
@@ -8,11 +8,11 @@ repositories:
   mesh_tools:
     type: git
     url: https://github.com/naturerobots/mesh_tools.git
-    version: humble
+    version: lvr-update
   mesh_navigation:
     type: git
     url: https://github.com/naturerobots/mesh_navigation.git
-    version: humble
+    version: lvr-update
   move_base_flex:
     type: git
     url: https://github.com/naturerobots/move_base_flex.git


### PR DESCRIPTION
This is a reaction to the new mesh_navigation version, PR: https://github.com/naturerobots/mesh_navigation/pull/70

- Load standard mesh formats instead of just hdf5. Loading hdf5 ist still possible. In the current launch files, a "PLY" is loaded.
- Parameter for changing the mesh implementation. Implemented are "pmp" and "lvr". "pmp" is new and "lvr" is the implementation of the previous version.